### PR TITLE
Add additional .nro path

### DIFF
--- a/themezer-nx/source/utils.c
+++ b/themezer-nx/source/utils.c
@@ -17,7 +17,7 @@ const char *possibleThemeInstallerPaths[] = {
 };
 
 const char* GetThemeInstallerPath(){
-	for (int i = 0; i < 2; i++){
+	for (int i = 0; i < 3; i++){
 		if (access(possibleThemeInstallerPaths[i], F_OK) != -1){
 			return possibleThemeInstallerPaths[i];
 		}

--- a/themezer-nx/source/utils.c
+++ b/themezer-nx/source/utils.c
@@ -12,6 +12,7 @@ typedef struct {
 
 const char *possibleThemeInstallerPaths[] = {
 	"/switch/NXThemesInstaller.nro",
+	"/switch/NXThemesInstaller/NXThemesInstaller.nro",
 	"/switch/Switch_themes_Installer/NXThemesInstaller.nro"
 };
 


### PR DESCRIPTION
It's pretty common to use directories that replicate the original .nro name for all .nros even if this app in particular doesn't create additional files in the /switch/ directory, for the purpose of keeping an alphabetically organized directory and also containing .star files if created by homebrew menu. This covers people who do that but don't use hb app store, not sure why they use a different directory name anyway.